### PR TITLE
Bump Node images to 16.15 for fetch API

### DIFF
--- a/javascript/javascript-node-lts/data/Dockerfile
+++ b/javascript/javascript-node-lts/data/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-stretch-slim
+FROM node:16.15-stretch-slim
 WORKDIR /opt/
 COPY package*.json *lock src /opt/
 RUN npm install --production

--- a/typescript/typescript-node-lts/data/Dockerfile
+++ b/typescript/typescript-node-lts/data/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-stretch-slim AS builder
+FROM node:16.15-stretch-slim AS builder
 
 # Create a build stage, which compiles TS to regular ol' JS.
 WORKDIR /opt/
@@ -8,7 +8,7 @@ COPY src .
 RUN npm run build
 
 # This is the output image, which contains only the prebuilt JS.
-FROM node:16.14-stretch-slim
+FROM node:16.15-stretch-slim
 WORKDIR /opt/
 COPY package*.json /opt/
 RUN npm install --production


### PR DESCRIPTION
### Description

`fetch` was backported to Node 16 for 16.15.0 release so this can help devs have less dependencies.