### PR TITLE
Return error stack or message in Node + TS-Node scaffolds

### DIFF
--- a/javascript/javascript-node-lts/data/src/_init.js
+++ b/javascript/javascript-node-lts/data/src/_init.js
@@ -21,6 +21,11 @@ init()
     console.log(JSON.stringify(body));
   })
   .catch((e) => {
-    console.log(JSON.stringify({ error: e, status: 500 }));
+    console.log(
+      JSON.stringify({
+        error: e.stack || e.message,
+        status: 500,
+      })
+    );
     process.exit(1);
   });

--- a/typescript/typescript-node-lts/data/src/_init.ts
+++ b/typescript/typescript-node-lts/data/src/_init.ts
@@ -22,15 +22,20 @@ async function init() {
 }
 
 init()
-  .then(body => {
+  .then((body) => {
     if (typeof body === "string") {
       console.log(JSON.stringify({ body }));
       return;
     }
-    console.log(JSON.stringify(body))
+    console.log(JSON.stringify(body));
   })
-  .catch(e => {
+  .catch((e: Error) => {
     // TODO: Log error and stack trace.
-    console.log(JSON.stringify({ error: e, status: 500 }))
+    console.log(
+      JSON.stringify({
+        error: e.stack || e.message,
+        status: 500,
+      })
+    );
     process.exit(1);
   });


### PR DESCRIPTION
### Description

Prior to this change, "strinfigying" an Error object just returns an empty object, so the error is not useful at all. This returns a more useful stack or message if the stack isn't available. We can potentially visually display stacks in the CLI and Inngest Cloud to make debugging issues easier for developers.

This also has potential to keep it more consistent across languages using a string that we can format.

**Previously**
```
Errors
Step 'step-1': Non-zero status code: 1
Output: 2022-07-06T15:51:13.790083804Z {"error":{},"status":500}
```


**After change**
```
Errors
Step 'step-1': Non-zero status code: 1
Output: 2022-07-06T15:51:13.790083804Z {"error":"TypeError: Cannot read properties of undef
ined (reading 'external_id')\n    at run (file:///opt/build/index.js:40:16)\n    at process
TicksAndRejections (node:internal/process/task_queues:96:5)\n    at async init (file:///opt
/build/_init.js:15:20)","status":500}
```